### PR TITLE
feat(usb_host): Adding support for usb host hid

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,4 @@ jobs:
       with:
         esp_idf_version: release-v5.2
         path: '.'
+        target: esp32s3

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
@@ -26,7 +26,7 @@ jobs:
         command: 'idf.py build'
 
     - name: Upload Build Outputs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-artifacts
         path: |
@@ -36,7 +36,7 @@ jobs:
           build/flash_args
 
     - name: Attach files to release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: ${{ github.event.release && github.event.action == 'published' }}
       with:
         files: |

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 build/
 sdkconfig
 sdkconfig.old
+managed_components/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,11 @@ set(EXTRA_COMPONENT_DIRS
 
 set(
   COMPONENTS
-  # TODO: add additional esp-idf and espp components you want to use to the line below:
-  "main esptool_py logger task"
+  "main esptool_py driver usb adc cli filters logger nvs task timer usb_host_hid"
   CACHE STRING
   "List of components to include"
   )
 
-# TODO: update this with your project's name
-project(template)
+project(esp-usb-latency-test)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Some controllers, such as
   to it, otherwise we just get a single report) see [additional
   information](https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/USB-HID-Notes.md#80-04)
 
+⚠️ Right now xbox controllers (elite 2 model 1797 and xbox model 1708) report `No
+HID device at USB port 1`. I believe this is because they show up as multiple
+devices. ⚠️
+
+I believe the warning above is related to these issues:
+* https://github.com/espressif/esp-idf/issues/12667
+* https://github.com/espressif/esp-idf/issues/12554
+
 ## Use
 
 It's recommended to use the

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ This repository also contains a couple python analysis tools:
 
 ## Hardware Needed
 
-1. ESP32S3 dev board, such as QtPy ESP32S3.
+1. ESP32S3 dev board - ideally one with USB connectors for both a UART and the
+   native USB so that you can gather log data more easily. I recommend the
+   [ESP32-S3-DevKitC-1 v1.0](https://www.adafruit.com/product/5312)
 2. Dupont wires to connect to button on controller (patch into button and gnd
    signal).
    

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ This repository also contains a couple python analysis tools:
    ([mouser
    link](https://www.mouser.com/ProductDetail/Espressif-Systems/ESP32-S3-USB-OTG?qs=TCDPyi3sCW2REilQUpYpuw%3D%3D)).
    You will need to make sure it can provide VBUS power to the device under
-   test.
+   test. NOTE: for the `ESP32-S3-USB-OTG` devkit to provide VBUS power, you must
+   plug it into a host, it will pass through the host power to the device.
+   Otherwise you will need to solder on a battery to the devkit and enable the
+   battery power using the on-board switch.
 2. Dupont wires to connect to button on controller (patch into button and gnd
    signal).
    

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ This repository also contains a couple python analysis tools:
 2. Dupont wires to connect to button on controller (patch into button and gnd
    signal).
    
+Test Setup:
+![image](https://github.com/finger563/esp-usb-latency-test/assets/213467/ea2a5b83-1ef8-4884-be31-db12847c7a41)
+
 For measurement method (1/ADC) above, you'll also need:
 3. Photo-diode for measuring the brightness / light of the screen. I used
    [Amazon 3mm flat head PhotoDiode](https://www.amazon.com/dp/B07VNSX74J).
@@ -161,3 +164,14 @@ idf.py -p PORT flash monitor
 (To exit the serial monitor, type ``Ctrl-]``.)
 
 See the Getting Started Guide for full steps to configure and use ESP-IDF to build 
+
+## Output:
+
+Test Setup:
+![image](https://github.com/finger563/esp-usb-latency-test/assets/213467/ea2a5b83-1ef8-4884-be31-db12847c7a41)
+
+Xbox-Alike:
+![CleanShot 2024-07-05 at 14 31 19](https://github.com/finger563/esp-usb-latency-test/assets/213467/d8f3aef3-4ed2-4c83-b50d-a073672c6dff)
+
+PS5 DualSense:
+![CleanShot 2024-07-05 at 14 33 03](https://github.com/finger563/esp-usb-latency-test/assets/213467/26dea419-55cd-478c-8f5d-a147761a1d53)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Some controllers, such as
 * `Xbox Wireless Controller (model 1708)` (note: currently doesn't work because
   it shows up as multiple usb devices)
 * `Nintendo Switch Pro Controller` (note: it appears we need to send some data
-  to it, otherwise we just get a single report)
+  to it, otherwise we just get a single report) see [additional
+  information](https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/USB-HID-Notes.md#80-04)
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ See the Getting Started Guide for full steps to configure and use ESP-IDF to bui
 Test Setup:
 ![image](https://github.com/finger563/esp-usb-latency-test/assets/213467/ea2a5b83-1ef8-4884-be31-db12847c7a41)
 
+Testing multiple controllers:
+![CleanShot 2024-07-05 at 16 13 07](https://github.com/finger563/esp-usb-latency-test/assets/213467/2d874ad8-d968-4a78-8a9a-e8fc028b5e92)
+
 Xbox-Alike:
 ![CleanShot 2024-07-05 at 14 31 19](https://github.com/finger563/esp-usb-latency-test/assets/213467/d8f3aef3-4ed2-4c83-b50d-a073672c6dff)
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ This repository also contains a couple python analysis tools:
    plug it into a host, it will pass through the host power to the device.
    Otherwise you will need to solder on a battery to the devkit and enable the
    battery power using the on-board switch.
+   * If you decide to use something like a ESP32-S3-DevKitC-1, then you'll need
+     to modify the board (remove / bypass D7) so that the UART USB / VCC-5V can
+     power the USB device port.
 2. Dupont wires to connect to button on controller (patch into button and gnd
    signal).
    

--- a/README.md
+++ b/README.md
@@ -62,11 +62,15 @@ that you can see the ADC values for the screen on/off state based on the screen
 appropriate upper/lower thresholds accordingly to take data.
 
 Some controllers, such as 
-* `Xbox Elite Wireless Controller 2 (model 1797)`
-* `Xbox Wireless Controller (model 1708)`
-* `Playstation Dualsense (model CFI-SCT1W)`
-* `Nintendo Switch Pro Controller`
 * `8BitDo Pro 2` (note: it should be set to `D` compatibility setting)
+* `Backbone One` (USB Receptacle)
+* `Playstation Dualsense (model CFI-SCT1W)`
+* `Xbox Elite Wireless Controller 2 (model 1797)` (note: currently doesn't work
+  because it shows up as multiple usb devices)
+* `Xbox Wireless Controller (model 1708)` (note: currently doesn't work because
+  it shows up as multiple usb devices)
+* `Nintendo Switch Pro Controller` (note: it appears we need to send some data
+  to it, otherwise we just get a single report)
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ This repository also contains a couple python analysis tools:
    [ESP32-S3-DevKitC-1 v1.0](https://www.adafruit.com/product/5312)
 2. Dupont wires to connect to button on controller (patch into button and gnd
    signal).
+3. If you use the DevKitC (as linked above), you'll likely also need some way to
+   convert USB micro-b to C. I recommend [this usb-micro-b to usb-c
+   cable](https://www.amazon.com/Cable-Matters-Micro-Braided-Jacket/dp/B00UUBRX0Y/ref=sr_1_6).
+   That will allow you to plug in a USB-c controller to the USB plug on the
+   dev-kit. You'll then be able to use a standard usb-A to usb-micro-b cable to
+   connect up to the UART port.
    
 For measurement method (1/ADC) above, you'll also need:
 3. Photo-diode for measuring the brightness / light of the screen. I used

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ This repository also contains a couple python analysis tools:
    [esp32-s3-usb-otg
    devkit](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-usb-otg/user_guide.html)
    ([mouser
-   link](https://www.mouser.com/ProductDetail/Espressif-Systems/ESP32-S3-USB-OTG?qs=TCDPyi3sCW2REilQUpYpuw%3D%3D))
+   link](https://www.mouser.com/ProductDetail/Espressif-Systems/ESP32-S3-USB-OTG?qs=TCDPyi3sCW2REilQUpYpuw%3D%3D)).
+   You will need to make sure it can provide VBUS power to the device under
+   test.
 2. Dupont wires to connect to button on controller (patch into button and gnd
    signal).
    

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Some controllers, such as
 * `Xbox Wireless Controller (model 1708)`
 * `Playstation Dualsense (model CFI-SCT1W)`
 * `Nintendo Switch Pro Controller`
+* `8BitDo Pro 2` (note: it should be set to `D` compatibility setting)
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,12 @@ This repository also contains a couple python analysis tools:
 
 1. ESP32S3 dev board - ideally one with USB connectors for both a UART and the
    native USB so that you can gather log data more easily. I recommend the
-   [ESP32-S3-DevKitC-1 v1.0](https://www.adafruit.com/product/5312)
+   [esp32-s3-usb-otg
+   devkit](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-usb-otg/user_guide.html)
+   ([mouser
+   link](https://www.mouser.com/ProductDetail/Espressif-Systems/ESP32-S3-USB-OTG?qs=TCDPyi3sCW2REilQUpYpuw%3D%3D))
 2. Dupont wires to connect to button on controller (patch into button and gnd
    signal).
-3. If you use the DevKitC (as linked above), you'll likely also need some way to
-   convert USB micro-b to C. I recommend [this usb-micro-b to usb-c
-   cable](https://www.amazon.com/Cable-Matters-Micro-Braided-Jacket/dp/B00UUBRX0Y/ref=sr_1_6).
-   That will allow you to plug in a USB-c controller to the USB plug on the
-   dev-kit. You'll then be able to use a standard usb-A to usb-micro-b cable to
-   connect up to the UART port.
    
 For measurement method (1/ADC) above, you'll also need:
 3. Photo-diode for measuring the brightness / light of the screen. I used

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,0 +1,15 @@
+dependencies:
+  espressif/usb_host_hid:
+    component_hash: 9295f5fc8761aba10ff8ae6e734621bdf20f43b194c4d700b238ba320e59b176
+    source:
+      service_url: https://api.components.espressif.com/
+      type: service
+    version: 1.0.2
+  idf:
+    component_hash: null
+    source:
+      type: idf
+    version: 5.2.2
+manifest_hash: d72796683f8898bcadadea4a67adee73becfdb138865a596ba5aca9200a7271d
+target: esp32s3
+version: 1.0.0

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,0 +1,4 @@
+## IDF Component Manager Manifest File
+dependencies:
+  idf: ">=4.4"
+  usb_host_hid: "^1.0.1"

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -53,7 +53,8 @@ typedef struct {
 static const char *hid_proto_name_str[] = {
   "NONE",
   "KEYBOARD",
-  "MOUSE"
+  "MOUSE",
+  "GAMEPAD",
 };
 
 static void hid_host_generic_report_callback(const uint8_t *const data, const int length);
@@ -266,6 +267,19 @@ static void hid_host_device_event(hid_host_device_handle_t hid_device_handle,
   case HID_HOST_DRIVER_EVENT_CONNECTED: {
     logger.info("HID Device, protocol '{}' CONNECTED",
              hid_proto_name_str[dev_params.proto]);
+
+    // get the device info
+    hid_host_dev_info_t dev_info;
+    ESP_ERROR_CHECK(hid_host_get_device_info(hid_device_handle, &dev_info));
+    // convert the wchar_t strings to utf-8
+    char manufacturer[128] = { 0 };
+    char product[128] = { 0 };
+    char serial[128] = { 0 };
+    wcstombs(manufacturer, dev_info.iManufacturer, sizeof(manufacturer));
+    wcstombs(product, dev_info.iProduct, sizeof(product));
+    wcstombs(serial, dev_info.iSerialNumber, sizeof(serial));
+    logger.info("  - VID: 0x{:04X}, PID: 0x{:04X}, Manufacturer: '{}', Product: '{}', Serial: '{}'",
+             dev_info.VID, dev_info.PID, manufacturer, product, serial);
 
     const hid_host_device_config_t dev_config = {
       .callback = hid_host_interface_callback,

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,10 +1,71 @@
 #include <chrono>
 #include <thread>
 
+#include "usb/usb_host.h"
+#include "usb/hid_host.h"
+#include "usb/hid_usage_keyboard.h"
+#include "usb/hid_usage_mouse.h"
+
 #include "logger.hpp"
 #include "task.hpp"
 
 using namespace std::chrono_literals;
+
+static espp::Logger logger({.tag = "esp-usb-latency-test", .level = espp::Logger::Verbosity::DEBUG});
+
+
+QueueHandle_t app_event_queue = NULL;
+
+/**
+ * @brief APP event group
+ *
+ * Application logic can be different. There is a one among other ways to distingiush the
+ * event by application event group.
+ * In this example we have two event groups:
+ * APP_EVENT            - General event, which is APP_QUIT_PIN press event (Generally, it is IO0).
+ * APP_EVENT_HID_HOST   - HID Host Driver event, such as device connection/disconnection or input report.
+ */
+typedef enum {
+  APP_EVENT = 0,
+  APP_EVENT_HID_HOST
+} app_event_group_t;
+
+/**
+ * @brief APP event queue
+ *
+ * This event is used for delivering the HID Host event from callback to a task.
+ */
+typedef struct {
+  app_event_group_t event_group;
+  /* HID Host - Device related info */
+  struct {
+    hid_host_device_handle_t handle;
+    hid_host_driver_event_t event;
+    void *arg;
+  } hid_host_device;
+} app_event_queue_t;
+
+/**
+ * @brief HID Protocol string names
+ */
+static const char *hid_proto_name_str[] = {
+  "NONE",
+  "KEYBOARD",
+  "MOUSE"
+};
+
+static void hid_host_generic_report_callback(const uint8_t *const data, const int length);
+static void hid_host_interface_callback(hid_host_device_handle_t hid_device_handle,
+                                        const hid_host_interface_event_t event,
+                                        void *arg);
+static void hid_host_device_event(hid_host_device_handle_t hid_device_handle,
+                                  const hid_host_driver_event_t event,
+                                  void *arg);
+static void hid_host_device_callback(hid_host_device_handle_t hid_device_handle,
+                                     const hid_host_driver_event_t event,
+                                     void *arg);
+static void usb_lib_task(void *arg);
+
 
 extern "C" void app_main(void) {
   static auto start = std::chrono::high_resolution_clock::now();
@@ -13,9 +74,75 @@ extern "C" void app_main(void) {
     return std::chrono::duration<float>(now - start).count();
   };
 
-  espp::Logger logger({.tag = "Template", .level = espp::Logger::Verbosity::DEBUG});
-
   logger.info("Bootup");
+
+  app_event_queue_t evt_queue;
+
+  /*
+   * Create usb_lib_task to:
+   * - initialize USB Host library
+   * - Handle USB Host events while APP pin in in HIGH state
+   */
+  auto task_created = xTaskCreatePinnedToCore(usb_lib_task,
+                                         "usb_events",
+                                         4096,
+                                         xTaskGetCurrentTaskHandle(),
+                                         2, NULL, 0);
+  assert(task_created == pdTRUE);
+
+  // Wait for notification from usb_lib_task to proceed
+  ulTaskNotifyTake(false, 1000);
+
+  /*
+   * HID host driver configuration
+   * - create background task for handling low level event inside the HID driver
+   * - provide the device callback to get new HID Device connection event
+   */
+  const hid_host_driver_config_t hid_host_driver_config = {
+    .create_background_task = true,
+    .task_priority = 5,
+    .stack_size = 4096,
+    .core_id = 0,
+    .callback = hid_host_device_callback,
+    .callback_arg = NULL
+  };
+
+  ESP_ERROR_CHECK(hid_host_install(&hid_host_driver_config));
+
+  // Create queue
+  app_event_queue = xQueueCreate(10, sizeof(app_event_queue_t));
+
+  logger.info("Waiting for HID Device to be connected");
+
+  while (1) {
+    // Wait queue
+    if (xQueueReceive(app_event_queue, &evt_queue, portMAX_DELAY)) {
+      if (APP_EVENT == evt_queue.event_group) {
+        // User pressed button
+        usb_host_lib_info_t lib_info;
+        ESP_ERROR_CHECK(usb_host_lib_info(&lib_info));
+        if (lib_info.num_devices == 0) {
+          // End while cycle
+          break;
+        } else {
+          logger.warn("To shutdown example, remove all USB devices and press button again.");
+          // Keep polling
+        }
+      }
+
+      if (APP_EVENT_HID_HOST ==  evt_queue.event_group) {
+        hid_host_device_event(evt_queue.hid_host_device.handle,
+                              evt_queue.hid_host_device.event,
+                              evt_queue.hid_host_device.arg);
+      }
+    }
+  }
+
+  logger.info("HID Driver uninstall");
+  ESP_ERROR_CHECK(hid_host_uninstall());
+  xQueueReset(app_event_queue);
+  vQueueDelete(app_event_queue);
+
 
   // make a simple task that prints "Hello World!" every second
   espp::Task task({
@@ -36,4 +163,158 @@ extern "C" void app_main(void) {
     logger.debug("[{:.3f}] Hello World!", elapsed());
     std::this_thread::sleep_for(1s);
   }
+}
+
+/**
+ * @brief USB HID Host Generic Interface report callback handler
+ *
+ * 'generic' means anything else than mouse or keyboard
+ *
+ * @param[in] data    Pointer to input report data buffer
+ * @param[in] length  Length of input report data buffer
+ */
+static void hid_host_generic_report_callback(const uint8_t *const data, const int length)
+{
+  logger.debug("Generic report: ");
+  for (int i = 0; i < length; i++) {
+    printf("%02X", data[i]);
+  }
+  putchar('\r');
+}
+
+/**
+ * @brief USB HID Host interface callback
+ *
+ * @param[in] hid_device_handle  HID Device handle
+ * @param[in] event              HID Host interface event
+ * @param[in] arg                Pointer to arguments, does not used
+ */
+static void hid_host_interface_callback(hid_host_device_handle_t hid_device_handle,
+                                        const hid_host_interface_event_t event,
+                                        void *arg)
+{
+  uint8_t data[64] = { 0 };
+  size_t data_length = 0;
+  hid_host_dev_params_t dev_params;
+  ESP_ERROR_CHECK(hid_host_device_get_params(hid_device_handle, &dev_params));
+
+  switch (event) {
+  case HID_HOST_INTERFACE_EVENT_INPUT_REPORT:
+    ESP_ERROR_CHECK(hid_host_device_get_raw_input_report_data(hid_device_handle,
+                                                              data,
+                                                              64,
+                                                              &data_length));
+    hid_host_generic_report_callback(data, data_length);
+    break;
+  case HID_HOST_INTERFACE_EVENT_DISCONNECTED:
+    logger.info("HID Device, protocol '%s' DISCONNECTED",
+             hid_proto_name_str[dev_params.proto]);
+    ESP_ERROR_CHECK(hid_host_device_close(hid_device_handle));
+    break;
+  case HID_HOST_INTERFACE_EVENT_TRANSFER_ERROR:
+    logger.info("HID Device, protocol '%s' TRANSFER_ERROR",
+             hid_proto_name_str[dev_params.proto]);
+    break;
+  default:
+    logger.error("HID Device, protocol '%s' Unhandled event",
+             hid_proto_name_str[dev_params.proto]);
+    break;
+  }
+}
+
+/**
+ * @brief USB HID Host Device event
+ *
+ * @param[in] hid_device_handle  HID Device handle
+ * @param[in] event              HID Host Device event
+ * @param[in] arg                Pointer to arguments, does not used
+ */
+static void hid_host_device_event(hid_host_device_handle_t hid_device_handle,
+                                  const hid_host_driver_event_t event,
+                                  void *arg)
+{
+  hid_host_dev_params_t dev_params;
+  ESP_ERROR_CHECK(hid_host_device_get_params(hid_device_handle, &dev_params));
+
+  switch (event) {
+  case HID_HOST_DRIVER_EVENT_CONNECTED: {
+    logger.info("HID Device, protocol '%s' CONNECTED",
+             hid_proto_name_str[dev_params.proto]);
+
+    const hid_host_device_config_t dev_config = {
+      .callback = hid_host_interface_callback,
+      .callback_arg = NULL
+    };
+
+    ESP_ERROR_CHECK(hid_host_device_open(hid_device_handle, &dev_config));
+    if (HID_SUBCLASS_BOOT_INTERFACE == dev_params.sub_class) {
+      ESP_ERROR_CHECK(hid_class_request_set_protocol(hid_device_handle, HID_REPORT_PROTOCOL_BOOT));
+      if (HID_PROTOCOL_KEYBOARD == dev_params.proto) {
+        ESP_ERROR_CHECK(hid_class_request_set_idle(hid_device_handle, 0, 0));
+      }
+    }
+    ESP_ERROR_CHECK(hid_host_device_start(hid_device_handle));
+  } break;
+  default:
+    break;
+  }
+}
+
+/**
+ * @brief HID Host Device callback
+ *
+ * Puts new HID Device event to the queue
+ *
+ * @param[in] hid_device_handle HID Device handle
+ * @param[in] event             HID Device event
+ * @param[in] arg               Not used
+ */
+static void hid_host_device_callback(hid_host_device_handle_t hid_device_handle,
+                              const hid_host_driver_event_t event,
+                              void *arg)
+{
+  app_event_queue_t evt_queue;
+  memset(&evt_queue, 0, sizeof(evt_queue));
+  evt_queue.event_group = APP_EVENT_HID_HOST;
+  // HID Host Device related info
+  evt_queue.hid_host_device.handle = hid_device_handle;
+  evt_queue.hid_host_device.event = event;
+  evt_queue.hid_host_device.arg = arg;
+
+  if (app_event_queue) {
+    xQueueSend(app_event_queue, &evt_queue, 0);
+  }
+}
+
+/**
+ * @brief Start USB Host install and handle common USB host library events while app pin not low
+ *
+ * @param[in] arg  Not used
+ */
+static void usb_lib_task(void *arg)
+{
+  usb_host_config_t host_config;
+  memset(&host_config, 0, sizeof(host_config));
+  host_config.skip_phy_setup = false;
+  host_config.intr_flags = ESP_INTR_FLAG_LEVEL1;
+
+  ESP_ERROR_CHECK(usb_host_install(&host_config));
+  xTaskNotifyGive(static_cast<TaskHandle_t>(arg));
+
+  while (true) {
+    uint32_t event_flags;
+    usb_host_lib_handle_events(portMAX_DELAY, &event_flags);
+    // In this example, there is only one client registered
+    // So, once we deregister the client, this call must succeed with ESP_OK
+    if (event_flags & USB_HOST_LIB_EVENT_FLAGS_NO_CLIENTS) {
+      ESP_ERROR_CHECK(usb_host_device_free_all());
+      break;
+    }
+  }
+
+  logger.info("USB shutdown");
+  // Clean up USB Host
+  vTaskDelay(10); // Short delay to allow clients clean-up
+  ESP_ERROR_CHECK(usb_host_uninstall());
+  vTaskDelete(NULL);
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,6 +1,8 @@
 #include <chrono>
 #include <thread>
 
+#include <driver/gpio.h>
+
 #include "usb/usb_host.h"
 #include "usb/hid_host.h"
 #include "usb/hid_usage_keyboard.h"
@@ -75,6 +77,11 @@ extern "C" void app_main(void) {
   };
 
   logger.info("Bootup");
+
+  // set GPIO12 (dev_vbus_en) high to enable VBUS output to USB device
+  static constexpr auto GPIO_DEV_VBUS_EN = GPIO_NUM_12;
+  gpio_set_direction(GPIO_DEV_VBUS_EN, GPIO_MODE_OUTPUT);
+  gpio_set_level(GPIO_DEV_VBUS_EN, 1);
 
   app_event_queue_t evt_queue;
 

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,23 +1,15 @@
-# TODO: uncomment one of these if you want to support a specifc target by default
-# CONFIG_IDF_TARGET="esp32"
-# CONFIG_IDF_TARGET="esp32s2"
-# CONFIG_IDF_TARGET="esp32s3"
-# CONFIG_IDF_TARGET="esp32c3"
+CONFIG_IDF_TARGET="esp32s3"
 
-# TODO: uncomment if you want freertos to run at 1 khz instead of the default 100 hz
-# CONFIG_FREERTOS_HZ=1000
+CONFIG_FREERTOS_HZ=1000
 
-# TODO: uncomment if you want to run the esp at max clock speed (240 mhz)
 # ESP32-specific
 #
-# CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
-# CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=240
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=240
 
-# TODO: uncomment if you want to update the event and main task stask sizes
 # Common ESP-related
 #
-# CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
-# CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
 
-# TODO: uncomment if you want to enable exceptions (which may be needed by certain components such as cli)
-# CONFIG_COMPILER_CXX_EXCEPTIONS=y
+CONFIG_COMPILER_CXX_EXCEPTIONS=y


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add dependency (via esp idf component registry) to `usb_host_hid` component
* Copy some of the code from [esp-idf/examples](https://github.com/espressif/esp-idf/blob/master/examples/peripherals/usb/host/hid/main/hid_host_example.c) for usb host hid

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows this repo to actually have USB host functionality to receive input reports from attached gamepads.

Related example: https://github.com/esp32beans/ESP32_USB_Host_HID

⚠️ Right now xbox controllers (elite 2 model 1797 and xbox model 1708) report `No HID device at USB port 1`. I believe this is because they show up as multiple devices. ⚠️ 

I believe the warning above is related to these issues:
* https://github.com/espressif/esp-idf/issues/12667
* https://github.com/espressif/esp-idf/issues/12554

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building `main` and running it on a ESP32-S3-USB-OTG

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
Test Setup:
![image](https://github.com/finger563/esp-usb-latency-test/assets/213467/ea2a5b83-1ef8-4884-be31-db12847c7a41)

![CleanShot 2024-07-05 at 16 13 07](https://github.com/finger563/esp-usb-latency-test/assets/213467/2d874ad8-d968-4a78-8a9a-e8fc028b5e92)

Xbox-Alike:
![CleanShot 2024-07-05 at 14 31 19](https://github.com/finger563/esp-usb-latency-test/assets/213467/d8f3aef3-4ed2-4c83-b50d-a073672c6dff)

PS5 DualSense:
![CleanShot 2024-07-05 at 14 33 03](https://github.com/finger563/esp-usb-latency-test/assets/213467/26dea419-55cd-478c-8f5d-a147761a1d53)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
